### PR TITLE
Add example of how to fix the sql.DB panic issue 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run show-customers command",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {},
+            "args": [
+                "show-customers"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This fixes the panics we were getting for the `show-customers` command (details in comments). This just changes one command, but this same pattern can be applied to the rest of the commands. 